### PR TITLE
HACK: Disable allow null terminated messages.

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -284,6 +284,14 @@ bool checkreturn pb_decode_tag(pb_istream_t *stream, pb_wire_type_t *wire_type, 
     {
         return false;
     }
+
+#if ALLOW_NULL_TERMINATED_MSGS
+    if (temp == 0)
+    {
+        *eof = true; /* Special feature: allow 0-terminated messages. */
+        return false;
+    }
+#endif
     
     *tag = temp >> 3;
     *wire_type = (pb_wire_type_t)(temp & 7);


### PR DESCRIPTION
* This was resulting in an issue were pb_encode() would returning true even though it have decoded a 0 tag.
* This has been fixed in the latest version of nanopb that Ivan is currently working on in, feat/nanopb-update